### PR TITLE
Change dependency detection to detect kpsewhich instead of kpsepath 

### DIFF
--- a/lib/scripts/uucls.sh
+++ b/lib/scripts/uucls.sh
@@ -23,7 +23,7 @@ REMOTE="https://github.com/UtrechtUniversity/uucls.git"
 
 _check_for_dependencies_() {
 
-    if [[ ! $(command -v kpsepath) ]]; then
+    if [[ ! $(command -v kpsewhich) ]]; then
         echo "Kpathsea not found in PATH. Is LaTeX installed?"
         exit 1
     elif [[ ! $(command -v git) ]]; then


### PR DESCRIPTION
I ran into the problem that my TeXLive installation (Ubuntu 20.04) didn't provide ``kpsepath`` on my path. However, that specific tool wasn't used as far as I could see.

Thus, this PR changes the ``_check_for_dependencies_`` function to try to find ``kpsewhich`` instead of ``kpsewhich``, as the former is the tool that is actually used in the script.  

Not a major change, but hopefully it will help others ;)