### PR TITLE
Bugfix: graphicspath ignored in IfFileExists

### DIFF
--- a/lib/classes/beamerouterthemeuubeamer.sty
+++ b/lib/classes/beamerouterthemeuubeamer.sty
@@ -1,6 +1,6 @@
 % uubeamer - Outer theme
 %
-% Copyright 2022, J. Korbmacher (j.korbmacher@uu.nl)
+% Copyright 2023, J. Korbmacher (j.korbmacher@uu.nl)
 %
 % DISCLAIMER
 %
@@ -43,20 +43,29 @@
 \else
   \renewcommand{\@payoffpath}{UU_logo_2021_EN_BLACK_payoff.png}
 \fi
+\providecommand*{\input@path}{}
+\newcommand{\IfImageExists}[3]{%
+  \begingroup
+  \ifdefined\Ginput@path
+    \edef\input@path{\input@path\Ginput@path}%
+  \fi
+  \IfFileExists{#1}{#2}{#3}%
+  \endgroup
+}
 \newcommand{\@print@logo}{%
-    \IfFileExists{\@logopath}{\includegraphics{\@logopath}}{%
+    \IfImageExists{\@logopath}{\includegraphics{\@logopath}}{%
       \fbox{Warning! Logo not found.}
       \ClassWarning{uubeamer}{Couldn't locate the logo file. Put
         it somewhere where LaTeX can find it.}}
       }
 \newcommand{\@print@titlelogo}{%
-  \IfFileExists{\@titlelogopath}{\includegraphics[width=.5\linewidth]{\@titlelogopath}}{%
+  \IfImageExists{\@titlelogopath}{\includegraphics[width=.5\linewidth]{\@titlelogopath}}{%
       \fbox{Warning! Logo not found.}
       \ClassWarning{uubeamer}{Couldn't locate the logo file. Put
         it somewhere where LaTeX can find it.}}
       }
 \newcommand{\@print@payoff}{%
-  \IfFileExists{\@payoffpath}{\includegraphics[scale=0.5]{\@payoffpath}}{%
+  \IfImageExists{\@payoffpath}{\includegraphics[scale=0.5]{\@payoffpath}}{%
       \fbox{Warning! Payoff not found.}
       \ClassWarning{uubeamer}{Couldn't locate the logo file. Put
         it somewhere where LaTeX can find it.}}

--- a/lib/classes/uuletter2.cls
+++ b/lib/classes/uuletter2.cls
@@ -2,7 +2,7 @@
 %
 % A simple letter class for UU letters.
 %
-% Copyright 2021, J. Korbmacher (j.korbmacher@uu.nl)
+% Copyright 2023, J. Korbmacher (j.korbmacher@uu.nl)
 %
 % DISCLAIMER
 %
@@ -11,7 +11,7 @@
 % third parties without permission granted in advance.
 %
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{uuletter2}[2021/09/10 v1.0]
+\ProvidesClass{uuletter2}[2023/06/09 v1.1]
 \newif\if@dutch
 \newif\if@opensans
 \newif\if@merriweather
@@ -286,16 +286,25 @@
   \else
   \@website
   \fi}
+\providecommand*{\input@path}{}
+\newcommand{\IfImageExists}[3]{%
+  \begingroup
+  \ifdefined\Ginput@path
+    \edef\input@path{\input@path\Ginput@path}%
+  \fi
+  \IfFileExists{#1}{#2}{#3}%
+  \endgroup
+}
 \newcommand{\@printsignature}{%
   \if@signature
-  \IfFileExists{\@sigpath}{\includegraphics[width=3.5cm]{\@sigpath}\\}{%
+  \IfImageExists{\@sigpath}{\includegraphics[width=3.5cm]{\@sigpath}\\}{%
     \fbox{Warning! Signature not found}\\
   \ClassWarning{uuletter2}{You selected \protect\withsignature\space
     but LateX couldn't locate the signature.}}
   \else
   \fi}
 \newcommand{\@print@logo}{%
-    \IfFileExists{\@logopath}{\includegraphics{\@logopath}}{%
+    \IfImageExists{\@logopath}{\includegraphics{\@logopath}}{%
       \fbox{Warning! Logo not found.}
       \ClassWarning{uuletter2}{Couldn't locate the logo file. Put
         it somewhere where LaTeX can find it.}}}

--- a/lib/classes/uureport.cls
+++ b/lib/classes/uureport.cls
@@ -1,6 +1,6 @@
 % uureport.cls
 %
-% Copyright 2021, J. Korbmacher (j.korbmacher@uu.nl)
+% Copyright 2023, J. Korbmacher (j.korbmacher@uu.nl)
 %
 % DISCLAIMER
 %
@@ -9,7 +9,7 @@
 % third parties without permission granted in advance.
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{uureport}[2021/09/08 v1.0]
+\ProvidesClass{uureport}[2023/06/09 v1.1]
 
 % Some conditionals for later options
 
@@ -500,23 +500,19 @@
 
 %%%%% Internal commands to print layout
 
-% \newcommand{\@print@logo}{%
-%   \begin{minipage}[b][\@logoheight][t]{\@logowidth}
-%   \if@dutch
-%     \IfFileExists{UU_logo_2021_NL_RGB}{\includegraphics{UU_logo_2021_NL_RGB}}{%
-%       \fbox{Warning! Logo not found.}
-%       \ClassWarning{uudoc}{Couldn't locate the Dutch logo file. Put
-%         it somewhere where LaTeX can find it.}}
-%   \else
-%     \IfFileExists{UU_logo_2021_EN_RGB}{\includegraphics{UU_logo_2021_EN_RGB}}{%
-%       \fbox{Warning! Logo not found.}
-%       \ClassWarning{uudoc}{Couldn't locate the English logo file. Put
-%       it somewhere where LaTeX can find it.}}
-%   \fi
-% \end{minipage}}
+\providecommand*{\input@path}{}
+
+\newcommand{\IfImageExists}[3]{%
+  \begingroup
+  \ifdefined\Ginput@path
+    \edef\input@path{\input@path\Ginput@path}%
+  \fi
+  \IfFileExists{#1}{#2}{#3}%
+  \endgroup
+}
 
 \newcommand{\@print@logo}{%
-    \IfFileExists{\@logopath}{\includegraphics{\@logopath}}{%
+    \IfImageExists{\@logopath}{\includegraphics{\@logopath}}{%
       \fbox{Warning! Logo not found.}
       \ClassWarning{uuletter2}{Couldn't locate the logo file. Put
         it somewhere where LaTeX can find it.}}}


### PR DESCRIPTION
It's a known issue that IfFileExists ignores graphicspath, since the latter is only updated once an image is included. We ran into this problem when adding logos and signatures where not placed in the TDS but added via graphicspath (since we check if logos and signatures exist before trying to include them via IfFileExists). The solution is due to Daniel Diniz on stackexchange:

https://tex.stackexchange.com/questions/341526/how-to-use-graphicspath-in-iffileexists/

Closes: #12